### PR TITLE
disable the upcoming events links for now

### DIFF
--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -72,7 +72,7 @@ export default class UpcomingEvents extends HTMLElement {
                 </h2>
 
                 ${eventsByMonth[month].map((event) => {
-                  const { link, startTime, title } = event;
+                  const { startTime, title } = event;
                   const time = new Date(startTime);
                   const hours = time.getHours();
                   const formattedTitle = title.replace(/"/g, '\''); // TODO https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/issues/47
@@ -85,22 +85,17 @@ export default class UpcomingEvents extends HTMLElement {
                         style="color:var(--color-white); margin: .5rem auto;"
                         class="w-11/12 sm:w-10/12"
                       >
-                        <a
-                          href="${link}"
-                          alt="${formattedTitle}"
+                        <span
+                          class="inline-block w-8 text-center"
+                          style="background-color:var(--color-accent);"
                         >
-                          <span
-                            class="inline-block w-8 text-center"
-                            style="background-color:var(--color-accent);"
-                          >
-                            ${date}
-                          </span>
-                          <span
-                            style="color:var(--color-secondary);"
-                          >
-                            ${formattedTitle} @ ${hour}pm
-                          </span>
-                        </a>
+                          ${date}
+                        </span>
+                        <span
+                          style="color:var(--color-secondary);"
+                        >
+                          ${formattedTitle} @ ${hour}pm
+                        </span>
                       </h4>
                     </div>
                   `;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#66 

## Summary of Changes
1. Remove `<a>` links for now until event links are actually implemented, otherwise users will get a 404

<img width="716" alt="Screen Shot 2022-10-25 at 8 52 01 AM" src="https://user-images.githubusercontent.com/895923/197777832-2fd89b2c-5a30-4cf5-9c93-93fb2e8975e9.png">