### PR TITLE
pre-filter for only TT events from backend

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,11 +6,8 @@ import '../components/youtube-playlist/youtube-playlist.js';
 
 export default class Home extends HTMLElement {
   async connectedCallback() {
-    // TODO figure out how to filter for events (none of the suggestions seem to work?)
-    // https://github.com/node-fetch/node-fetch/issues/189#issuecomment-412213145
-    const events = (await fetch('https://www.analogstudios.net/api/v2/events')
+    const events = (await fetch('https://www.analogstudios.net/api/v2/events/?tag=tt')
       .then(resp => resp.json()))
-      .filter(event => event.tags.includes('tt'))
       .map(event => {
         return {
           ...event,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
The reason it was always returning unfiltered events was because of user error 🤕 
https://github.com/AnalogStudiosRI/api/issues/13#issuecomment-1312142904

> See this for more info - https://github.com/thescientist13/fetch-tests/pull/1

## Summary of Changes
1. Pre-filter from the backend only TT events