### PR TITLE
giving Tunesy logo a little more top padding on non desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See _package.json_ for all options:
 - `yarn test:tdd` - Run tests in watch mode
 - `yarn story:dev` - Run Storybook for development
 
-> _Hosted Storybook docs available through [GitHub Pages](http://analogstudiosri.github.io/www.tuesdaystunes.tv)_
+> _Hosted Storybook docs available through [GitHub Pages](http://analogstudiosri.github.io/www.tuesdaystunes.tv).  (Make sure to leave off the trailing slash!)_
 
 ## Release Management
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,7 +28,7 @@ export default class Home extends HTMLElement {
             <img
               src="/assets/tunesy.webp"
               alt="Picture of Tunesy"
-              class="w-2/5 block m-0 ml-auto mr-auto"
+              class="w-2/5 block ml-auto mr-auto mt-4 lg:mt-0"
               height="300"
               width="285"
             />


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Giving the Tunesy logo a little more headspace on lower screen devices

_Before_
![Screen Shot 2022-11-21 at 5 15 26 PM](https://user-images.githubusercontent.com/895923/203169496-576237d9-8b53-4eca-ab74-f39bb9a0a40c.png)

_After_
![Screen Shot 2022-11-21 at 5 15 33 PM](https://user-images.githubusercontent.com/895923/203169523-1f9bc10d-a918-406c-a29a-85abe258f52a.png)