### PR TITLE
add GitHub Action for publishing Storybook to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,32 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-18.04
+  
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+
+    - name: Install Dependencies
+      run: |
+        yarn install --frozen-lockfile
+
+    - name: Build
+      run: |
+        yarn clean && yarn story:build
+
+    - name: Deploy GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./storybook-static

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See _package.json_ for all options:
 - `yarn test:tdd` - Run tests in watch mode
 - `yarn story:dev` - Run Storybook for development
 
+> _Hosted Storybook docs available through [GitHub Pages](http://analogstudiosri.github.io/www.tuesdaystunes.tv)_
+
 ## Release Management
 
 The project is hosted by [Netlify](https://www.netlify.com/) and is setup to deploy continuously on every merge to the mainline branch in GitHub.  [GitHub Actions](https://github.com/features/actions) are used for continuous integration on PRs and Netlify will deploy preview builds for all PRs.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #86 

## Summary of Changes
1. Add GitHub Action for publishing Storybook docs to GitHub Pages
1. Document URL in _README.md_