### PR TITLE
rewrite assets path for storybook github pages builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Build
       run: |
-        yarn clean && yarn story:build
+        GH_PAGES=true yarn clean && yarn story:build
 
     - name: Deploy GitHub Pages
       uses: peaceiris/actions-gh-pages@v3

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -25,8 +25,8 @@ module.exports = {
         loader: 'string-replace-loader',
         options: {
           search: /\/assets\//g,
-          replace: '/www.tuesdaystunes.tv/assets/',
-        },
+          replace: '/www.tuesdaystunes.tv/assets/'
+        }
       });
     }
     return config;

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -12,8 +12,9 @@ module.exports = {
     '@storybook/addon-postcss'
   ],
   framework: '@storybook/web-components',
-  // set publicPath (e.g. `<base href="..." />) for GitHub Pages
+  // set publicPath (e.g. `<base href="..." />`) for GitHub Pages
   // https://github.com/storybookjs/storybook/issues/12444#issuecomment-1179671255
+  // Note: Used string-replace-loader@^2.x for webpack v4 compat to support current Storybook
   webpackFinal: async (config) => {
     if (process.env.GH_PAGES) {
       config.module.rules.push({

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   staticDirs: ['../src'],
   stories: [
@@ -9,5 +11,23 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-postcss'
   ],
-  framework: '@storybook/web-components'
+  framework: '@storybook/web-components',
+  // set publicPath (e.g. `<base href="..." />) for GitHub Pages
+  // https://github.com/storybookjs/storybook/issues/12444#issuecomment-1179671255
+  webpackFinal: async (config) => {
+    if (process.env.GH_PAGES) {
+      config.module.rules.push({
+        test: /.js$/,
+        include: [
+          path.resolve(__dirname, '../src/components')
+        ],
+        loader: 'string-replace-loader',
+        options: {
+          search: /\/assets\//g,
+          replace: '/www.tuesdaystunes.tv/assets/',
+        },
+      });
+    }
+    return config;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "http-server": "^14.1.1",
     "lit-html": "^2.3.1",
     "rimraf": "^3.0.2",
+    "string-replace-loader": "^2.3.0",
     "stylelint": "^13.8.0",
     "stylelint-a11y": "^1.2.3",
     "stylelint-config-standard": "^20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10886,6 +10886,14 @@ stream-shift@^1.0.0:
   resolved "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+string-replace-loader@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-2.3.0.tgz#7f29be7d73c94dd92eccd5c5a15651181d7ecd3d"
+  integrity sha512-HYBIHStViMKLZC/Lehxy42OuwsBaPzX/LjcF5mkJlE2SnHXmW6SW6eiHABTXnY8ZCm/REbdJ8qnA0ptmIzN0Ng==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^2.6.5"
+
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #94 

## Summary of Changes
1. Set a "public path" / base `href` for GitHub pages deployments to account for sub path hosting 

Can confirm it works for local testing at least 🤞 
![Screen Shot 2022-12-03 at 2 52 52 PM](https://user-images.githubusercontent.com/895923/205459325-b19d0a7e-4d3a-434e-93de-d4852406384a.png)