### PR TITLE
refactor test mocks to only have future events

### DIFF
--- a/src/components/upcoming-events/mock-events.js
+++ b/src/components/upcoming-events/mock-events.js
@@ -1,5 +1,5 @@
 const SINGLE_EVENT = [{
-  title: 'Tuesday\'s Tunes Season 3 - Premier!',
+  title: 'Tuesday\'s Tunes Season 3 - Teaser Trailer!',
   startTime: Date.now() + 300000,
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.'
 }];
@@ -19,8 +19,8 @@ const MULTIPLE_EVENTS = [{
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
-  title: 'Tuesday\'s Tunes Season 3 - Teaser Trailer',
-  startTime: SINGLE_EVENT[0].startTime - (86400000 * 5),
+  title: 'Tuesday\'s Tunes Season 3 - Premier',
+  startTime: SINGLE_EVENT[0].startTime + (86400000 * 5),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -98,11 +98,11 @@ describe('Components/Upcoming Events', () => {
   
       await events.updateComplete;
 
-      // 3, 1, 0, 2, 4 
+      // 1, 3, 0, 2, 4
       ORDERED_EVENTS = [{
-        ...MULTIPLE_EVENTS[3]
-      }, {
         ...MULTIPLE_EVENTS[1]
+      }, {
+        ...MULTIPLE_EVENTS[3]
       }, {
         ...MULTIPLE_EVENTS[0]
       }, {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #96 

## Summary of Changes
1. refactor test mocks to only have future events (since Upcoming Events never display past events)