### PR TITLE
display an indicator besides the next closest upcoming event

### DIFF
--- a/src/components/upcoming-events/mock-events.js
+++ b/src/components/upcoming-events/mock-events.js
@@ -1,4 +1,5 @@
 const SINGLE_EVENT = [{
+  id: 1,
   title: 'Tuesday\'s Tunes Season 3 - Teaser Trailer!',
   startTime: Date.now() + 300000,
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.'
@@ -6,6 +7,7 @@ const SINGLE_EVENT = [{
 
 // includes testing for multiple months, events list "overflow", and out of order events
 const MULTIPLE_EVENTS = [{
+  id: 3,
   title: 'Tuesday\'s Tunes Season 3 - Episode 1',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 15),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
@@ -14,16 +16,19 @@ const MULTIPLE_EVENTS = [{
   ...SINGLE_EVENT[0],
   link: 'http://www.facebook.com/'
 }, {
+  id: 4,
   title: 'Tuesday\'s Tunes Season 3 - Episode 2',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 30),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
+  id: 2,
   title: 'Tuesday\'s Tunes Season 3 - Premier',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 5),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
+  id: 5,
   title: 'Tuesday\'s Tunes Season 3 - Episode 3',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 45),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',

--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -74,7 +74,7 @@ export default class UpcomingEvents extends HTMLElement {
                     ? `<a title="${title}" href="${link}" class="underline">${formattedTitle}</a>`
                     : formattedTitle;
 
-                  if(!isNextUpcomingEventId && monthIdx === 0 && startTime >= now.getTime()) {
+                  if (!isNextUpcomingEventId && monthIdx === 0 && startTime >= now.getTime()) {
                     isNextUpcomingEventId = id;
                   }
 

--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -51,7 +51,9 @@ export default class UpcomingEvents extends HTMLElement {
         ${noEvents}
 
         ${
-          Object.keys(eventsByMonth).map((month) => {
+          Object.keys(eventsByMonth).map((month, monthIdx) => {
+            let isNextUpcomingEventId = null;
+
             return `
               <div class="mb-6">
                 <h3
@@ -62,7 +64,7 @@ export default class UpcomingEvents extends HTMLElement {
                 </h3>
 
                 ${eventsByMonth[month].map((event) => {
-                  const { startTime, title, link } = event;
+                  const { id, startTime, title, link } = event;
                   const time = new Date(startTime);
                   const hours = time.getHours();
                   const date = time.getDate();
@@ -71,6 +73,12 @@ export default class UpcomingEvents extends HTMLElement {
                   const eventLink = link
                     ? `<a title="${title}" href="${link}" class="underline">${formattedTitle}</a>`
                     : formattedTitle;
+
+                  if(!isNextUpcomingEventId && monthIdx === 0 && startTime >= now.getTime()) {
+                    isNextUpcomingEventId = id;
+                  }
+
+                  const isNextUpcomingEvent = isNextUpcomingEventId === id ? '👈' : '';
                     
                   return `
                     <div>
@@ -87,7 +95,7 @@ export default class UpcomingEvents extends HTMLElement {
                         <span
                           style="color:var(--color-secondary);"
                         >
-                          ${eventLink}
+                          ${eventLink} ${isNextUpcomingEvent}
                         </span>
                       </h4>
                     </div>

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -17,14 +17,15 @@ const MONTH_INDEX_MAPPER = [
   'December'
 ];
 
-function formatEventText(event) {
-  const { title, startTime } = event;
+function formatEventText(event, nextUpcomingEventId) {
+  const { id, title, startTime } = event;
   const time = new Date(startTime);
   const date = time.getDate();
   const hours = time.getHours();
   const hour = hours > 12 ? hours - 12 : hours;
+  const isNextUpcomingEvent = nextUpcomingEventId === id ? '👈' : '';
 
-  return `${date}${title}@${hour}pm`.replace(/ /g, '');
+  return `${date}${title}@${hour}pm ${isNextUpcomingEvent}`.replace(/ /g, '');
 }
 
 describe('Components/Upcoming Events', () => {
@@ -81,13 +82,13 @@ describe('Components/Upcoming Events', () => {
     it('should display the correct date details', () => {
       const event = SINGLE_EVENT[0];
       const headings = events.querySelectorAll('h4');
-      const display = formatEventText(event);
+      const display = formatEventText(event, event.id);
 
       expect(headings[0].textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);
     });
   });
 
-  describe('Multiple events', () => {
+  describe.only('Multiple events', () => {
     let ORDERED_EVENTS = [];
 
     before(async () => {
@@ -139,11 +140,21 @@ describe('Components/Upcoming Events', () => {
     });
 
     it('should display the correct date details', () => {
+      const now = new Date();
+      const month = now.getMonth();
       const headings = events.querySelectorAll('h4');
+      let isNextUpcomingEventId = null;
 
       headings.forEach((heading, idx) => {
         const event = ORDERED_EVENTS[idx];
-        const display = formatEventText(event);
+        const { startTime, id } = event;
+        const eventTime = new Date(startTime);
+
+        if (!isNextUpcomingEventId && eventTime.getMonth() === month && startTime >= now.getTime()) {
+          isNextUpcomingEventId = id;
+        }
+        
+        const display = formatEventText(event, isNextUpcomingEventId);
 
         expect(heading.textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #89 

![Screen Shot 2022-12-03 at 5 57 03 PM](https://user-images.githubusercontent.com/895923/205465581-8b827e9b-646a-437b-91c9-5998ae03e417.png)

## Summary of Changes
1. Add an 👈 indicator to next upcoming event
1. Updated test cases