### PR TITLE
add lint check for `describe.only` usage in specs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,6 +3,9 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module'
   },
+  plugins: [
+    'no-only-tests'
+  ],
   env: {
     browser: true,
     node: false
@@ -33,6 +36,7 @@ module.exports = {
     'no-irregular-whitespace': 2,
     'no-negated-in-lhs': 2,
     'no-obj-calls': 0,
+    'no-only-tests/no-only-tests': 2,
     'no-regex-spaces': 0,
     'no-sparse-arrays': 2,
     'no-unreachable': 2,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "autoprefixer": "^9.8.8",
     "babel-loader": "^8.2.5",
     "eslint": "^8.23.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "http-server": "^14.1.1",
     "lit-html": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -88,7 +88,7 @@ describe('Components/Upcoming Events', () => {
     });
   });
 
-  describe.only('Multiple events', () => {
+  describe('Multiple events', () => {
     let ORDERED_EVENTS = [];
 
     before(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5329,6 +5329,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Found a `describe.only` in our test cases 😱 

## Summary of Changes
1. Add ESLint rule for checking for `.only` usage
1. Remove `.only` usage