### PR TITLE
fix upcoming events indicator not auto incrementing

### DIFF
--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -63,7 +63,7 @@ export default class UpcomingEvents extends HTMLElement {
                   ${month}
                 </h3>
 
-                ${eventsByMonth[month].map((event) => {
+                ${eventsByMonth[month].map((event, eventIdx) => {
                   const { id, startTime, title, link } = event;
                   const time = new Date(startTime);
                   const hours = time.getHours();
@@ -74,11 +74,11 @@ export default class UpcomingEvents extends HTMLElement {
                     ? `<a title="${title}" href="${link}" class="underline">${formattedTitle}</a>`
                     : formattedTitle;
 
-                  if (!isNextUpcomingEventId && monthIdx === 0 && startTime >= now.getTime()) {
+                  if (monthIdx === 0 && !eventsByMonth[month][eventIdx + 1] && startTime >= now.getTime()) {
                     isNextUpcomingEventId = id;
                   }
 
-                  const isNextUpcomingEvent = isNextUpcomingEventId === id ? '👈' : '';
+                  const isNextUpcomingEventIndicator = isNextUpcomingEventId === id ? '👈' : '';
                     
                   return `
                     <div>
@@ -95,7 +95,7 @@ export default class UpcomingEvents extends HTMLElement {
                         <span
                           style="color:var(--color-secondary);"
                         >
-                          ${eventLink} ${isNextUpcomingEvent}
+                          ${eventLink} ${isNextUpcomingEventIndicator}
                         </span>
                       </h4>
                     </div>

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -149,8 +149,19 @@ describe('Components/Upcoming Events', () => {
         const event = ORDERED_EVENTS[idx];
         const { startTime, id } = event;
         const eventTime = new Date(startTime);
+        const nextEventIndex = idx + 1;
+        let hasNextMonthEvent = false;
+        
+        if (ORDERED_EVENTS[nextEventIndex]) {
+          const { startTime } = ORDERED_EVENTS[nextEventIndex];
+          const eventTime = new Date(startTime);
 
-        if (!isNextUpcomingEventId && eventTime.getMonth() === month && startTime >= now.getTime()) {
+          if (eventTime.getMonth() === month) {
+            hasNextMonthEvent = true;
+          }
+        }
+
+        if (eventTime.getMonth() === month && !hasNextMonthEvent && startTime >= now.getTime()) {
           isNextUpcomingEventId = id;
         }
         


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #102 

> Needs to be merged after #103 

## Summary of Changes
1. Refine logic for checking when to auto-increment to the next available upcoming event in the month