### PR TITLE
Updated Logic for Next Upcoming Event Indicator

### DIFF
--- a/src/components/upcoming-events/mock-events.js
+++ b/src/components/upcoming-events/mock-events.js
@@ -2,7 +2,7 @@ const SINGLE_EVENT = [{
   id: 1,
   title: 'Tuesday\'s Tunes Season 3 - Teaser Trailer!',
   startTime: Date.now() + 300000,
-  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
+  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.'
 }];
 
 // includes testing for multiple months, events list "overflow", and out of order events
@@ -11,7 +11,7 @@ const MULTIPLE_EVENTS = [{
   title: 'Tuesday\'s Tunes Season 3 - Episode 1',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 15),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/',
+  link: 'http://www.facebook.com/'
 }, {
   ...SINGLE_EVENT[0],
   link: 'http://www.facebook.com/'
@@ -20,19 +20,19 @@ const MULTIPLE_EVENTS = [{
   title: 'Tuesday\'s Tunes Season 3 - Episode 2',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 30),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/',
+  link: 'http://www.facebook.com/'
 }, {
   id: 2,
   title: 'Tuesday\'s Tunes Season 3 - Premier',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 5),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/',
+  link: 'http://www.facebook.com/'
 }, {
   id: 5,
   title: 'Tuesday\'s Tunes Season 3 - Episode 3',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 45),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/',
+  link: 'http://www.facebook.com/'
 }];
 
 const NO_EVENTS = [];

--- a/src/components/upcoming-events/mock-events.js
+++ b/src/components/upcoming-events/mock-events.js
@@ -7,28 +7,29 @@ const SINGLE_EVENT = [{
 
 // includes testing for multiple months, events list "overflow", and out of order events
 const MULTIPLE_EVENTS = [{
-  id: 3,
+  id: 4,
   title: 'Tuesday\'s Tunes Season 3 - Episode 1',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 15),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
   ...SINGLE_EVENT[0],
+  id: 2,
   link: 'http://www.facebook.com/'
 }, {
-  id: 4,
+  id: 5,
   title: 'Tuesday\'s Tunes Season 3 - Episode 2',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 30),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
-  id: 2,
+  id: 3,
   title: 'Tuesday\'s Tunes Season 3 - Premier',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 5),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
   link: 'http://www.facebook.com/'
 }, {
-  id: 5,
+  id: 6,
   title: 'Tuesday\'s Tunes Season 3 - Episode 3',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 45),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',

--- a/src/components/upcoming-events/mock-events.js
+++ b/src/components/upcoming-events/mock-events.js
@@ -2,7 +2,7 @@ const SINGLE_EVENT = [{
   id: 1,
   title: 'Tuesday\'s Tunes Season 3 - Teaser Trailer!',
   startTime: Date.now() + 300000,
-  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.'
+  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
 }];
 
 // includes testing for multiple months, events list "overflow", and out of order events
@@ -11,7 +11,7 @@ const MULTIPLE_EVENTS = [{
   title: 'Tuesday\'s Tunes Season 3 - Episode 1',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 15),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/'
+  link: 'http://www.facebook.com/',
 }, {
   ...SINGLE_EVENT[0],
   link: 'http://www.facebook.com/'
@@ -20,19 +20,19 @@ const MULTIPLE_EVENTS = [{
   title: 'Tuesday\'s Tunes Season 3 - Episode 2',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 30),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/'
+  link: 'http://www.facebook.com/',
 }, {
   id: 2,
   title: 'Tuesday\'s Tunes Season 3 - Premier',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 5),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/'
+  link: 'http://www.facebook.com/',
 }, {
   id: 5,
   title: 'Tuesday\'s Tunes Season 3 - Episode 3',
   startTime: SINGLE_EVENT[0].startTime + (86400000 * 45),
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elite.',
-  link: 'http://www.facebook.com/'
+  link: 'http://www.facebook.com/',
 }];
 
 const NO_EVENTS = [];

--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -22,11 +22,10 @@ export default class UpcomingEvents extends HTMLElement {
     const events = (this.getAttribute('events') ? JSON.parse(this.getAttribute('events')) : [])
       .filter((event) => event.startTime >= startOfCurrentMonthTime) // filter out old events except ones that are also in the current month
       .sort((a, b) => a.startTime < b.startTime ? -1 : 1); // sort newest to latest
+    const nextUpcomingEventIdx = events.findIndex(e => e?.startTime && e?.startTime > Date.now());
     const noEvents = events.length === 0
       ? '<h2 class="text-center">No Upcoming Events</h2>'
       : '';
-
-    const nextUpcomingEventIdx = events.findIndex(e => e?.startTime && e?.startTime > Date.now())
 
     // group events by month
     events.forEach((event, eventIdx) => {

--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -26,8 +26,10 @@ export default class UpcomingEvents extends HTMLElement {
       ? '<h2 class="text-center">No Upcoming Events</h2>'
       : '';
 
+    const nextUpcomingEventIdx = events.findIndex(e => e?.startTime && e?.startTime > Date.now())
+
     // group events by month
-    events.forEach((event) => {
+    events.forEach((event, eventIdx) => {
       const time = new Date(event.startTime);
       const month = time.getMonth();
       const monthKey = MONTH_INDEX_MAPPER[month];
@@ -36,7 +38,10 @@ export default class UpcomingEvents extends HTMLElement {
         eventsByMonth[monthKey] = [];
       }
 
-      eventsByMonth[monthKey].push(event);
+      eventsByMonth[monthKey].push({
+        ...event,
+        isNext: eventIdx === nextUpcomingEventIdx
+      });
     });
 
     /* eslint-disable indent */
@@ -51,8 +56,7 @@ export default class UpcomingEvents extends HTMLElement {
         ${noEvents}
 
         ${
-          Object.keys(eventsByMonth).map((month, monthIdx) => {
-            let isNextUpcomingEventId = null;
+          Object.keys(eventsByMonth).map(month => {
 
             return `
               <div class="mb-6">
@@ -63,8 +67,8 @@ export default class UpcomingEvents extends HTMLElement {
                   ${month}
                 </h3>
 
-                ${eventsByMonth[month].map((event, eventIdx) => {
-                  const { id, startTime, title, link } = event;
+                ${eventsByMonth[month].map(event => {
+                  const { startTime, title, link, isNext } = event;
                   const time = new Date(startTime);
                   const hours = time.getHours();
                   const date = time.getDate();
@@ -74,12 +78,6 @@ export default class UpcomingEvents extends HTMLElement {
                     ? `<a title="${title}" href="${link}" class="underline">${formattedTitle}</a>`
                     : formattedTitle;
 
-                  if (monthIdx === 0 && !eventsByMonth[month][eventIdx + 1] && startTime >= now.getTime()) {
-                    isNextUpcomingEventId = id;
-                  }
-
-                  const isNextUpcomingEventIndicator = isNextUpcomingEventId === id ? '👈' : '';
-                    
                   return `
                     <div>
                       <h4
@@ -95,7 +93,7 @@ export default class UpcomingEvents extends HTMLElement {
                         <span
                           style="color:var(--color-secondary);"
                         >
-                          ${eventLink} ${isNextUpcomingEventIndicator}
+                          ${eventLink} ${isNext ? '👈' : ''}
                         </span>
                       </h4>
                     </div>

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -17,15 +17,14 @@ const MONTH_INDEX_MAPPER = [
   'December'
 ];
 
-function formatEventText(event, nextUpcomingEventId) {
-  const { id, title, startTime } = event;
+function formatEventText(event) {
+  const { title, startTime, isNext } = event;
   const time = new Date(startTime);
   const date = time.getDate();
   const hours = time.getHours();
   const hour = hours > 12 ? hours - 12 : hours;
-  const isNextUpcomingEvent = nextUpcomingEventId === id ? '👈' : '';
 
-  return `${date}${title}@${hour}pm ${isNextUpcomingEvent}`.replace(/ /g, '');
+  return `${date}${title}@${hour}pm ${isNext ? '👈' : ''}`.replace(/ /g, '');
 }
 
 describe('Components/Upcoming Events', () => {
@@ -80,9 +79,11 @@ describe('Components/Upcoming Events', () => {
     });
 
     it('should display the correct date details', () => {
-      const event = SINGLE_EVENT[0];
       const headings = events.querySelectorAll('h4');
-      const display = formatEventText(event, event.id);
+      const display = formatEventText({
+        ...SINGLE_EVENT[0],
+        isNext: true
+      });
 
       expect(headings[0].textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);
     });
@@ -101,16 +102,21 @@ describe('Components/Upcoming Events', () => {
 
       // 1, 3, 0, 2, 4
       ORDERED_EVENTS = [{
-        ...MULTIPLE_EVENTS[1]
+        ...MULTIPLE_EVENTS[1],
+        isNext: true,
       }, {
-        ...MULTIPLE_EVENTS[3]
+        ...MULTIPLE_EVENTS[3],
+        isNext: false,
       }, {
-        ...MULTIPLE_EVENTS[0]
+        ...MULTIPLE_EVENTS[0],
+        isNext: false,
       }, {
-        ...MULTIPLE_EVENTS[2]
+        ...MULTIPLE_EVENTS[2],
+        isNext: false,
       }, {
-        ...MULTIPLE_EVENTS[4]
-      }];
+        ...MULTIPLE_EVENTS[4],
+        isNext: false,
+      }]
     });
 
     it('should not display the no upcoming events text', () => {
@@ -140,32 +146,11 @@ describe('Components/Upcoming Events', () => {
     });
 
     it('should display the correct date details', () => {
-      const now = new Date();
-      const month = now.getMonth();
       const headings = events.querySelectorAll('h4');
-      let isNextUpcomingEventId = null;
 
       headings.forEach((heading, idx) => {
         const event = ORDERED_EVENTS[idx];
-        const { startTime, id } = event;
-        const eventTime = new Date(startTime);
-        const nextEventIndex = idx + 1;
-        let hasNextMonthEvent = false;
-        
-        if (ORDERED_EVENTS[nextEventIndex]) {
-          const { startTime } = ORDERED_EVENTS[nextEventIndex];
-          const eventTime = new Date(startTime);
-
-          if (eventTime.getMonth() === month) {
-            hasNextMonthEvent = true;
-          }
-        }
-
-        if (eventTime.getMonth() === month && !hasNextMonthEvent && startTime >= now.getTime()) {
-          isNextUpcomingEventId = id;
-        }
-        
-        const display = formatEventText(event, isNextUpcomingEventId);
+        const display = formatEventText(event);
 
         expect(heading.textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);
       });

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -102,20 +102,15 @@ describe('Components/Upcoming Events', () => {
 
       // 1, 3, 0, 2, 4
       ORDERED_EVENTS = [{
-        ...MULTIPLE_EVENTS[1],
-        isNext: true
+        ...MULTIPLE_EVENTS[1]
       }, {
-        ...MULTIPLE_EVENTS[3],
-        isNext: false
+        ...MULTIPLE_EVENTS[3]
       }, {
-        ...MULTIPLE_EVENTS[0],
-        isNext: false
+        ...MULTIPLE_EVENTS[0]
       }, {
-        ...MULTIPLE_EVENTS[2],
-        isNext: false
+        ...MULTIPLE_EVENTS[2]
       }, {
-        ...MULTIPLE_EVENTS[4],
-        isNext: false
+        ...MULTIPLE_EVENTS[4]
       }];
     });
 
@@ -147,15 +142,20 @@ describe('Components/Upcoming Events', () => {
 
     it('should display the correct date details', () => {
       const headings = events.querySelectorAll('h4');
+      const nextUpcomingEventIdx = ORDERED_EVENTS.findIndex(e => e.startTime && e.startTime > Date.now())
 
       headings.forEach((heading, idx) => {
         const event = ORDERED_EVENTS[idx];
-        const display = formatEventText(event);
+        const display = formatEventText({
+          ...event,
+          isNext: event.id === ORDERED_EVENTS[nextUpcomingEventIdx].id
+        });
 
         expect(heading.textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);
       });
     });
 
+    // TODO use format formatEventText here
     it('should display the correct link details', () => {
       const links = events.querySelectorAll('a');
 

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -142,13 +142,13 @@ describe('Components/Upcoming Events', () => {
 
     it('should display the correct date details', () => {
       const headings = events.querySelectorAll('h4');
-      const nextUpcomingEventIdx = ORDERED_EVENTS.findIndex(e => e.startTime && e.startTime > Date.now())
+      const nextUpcomingEventIdx = ORDERED_EVENTS.findIndex(e => e.startTime && e.startTime > Date.now());
 
       headings.forEach((heading, idx) => {
         const event = ORDERED_EVENTS[idx];
         const display = formatEventText({
           ...event,
-          isNext: event.id === ORDERED_EVENTS[nextUpcomingEventIdx].id
+          isNext: idx === nextUpcomingEventIdx
         });
 
         expect(heading.textContent.replace(/\n/g, '').replace(/ /g, '')).to.equal(display);

--- a/src/components/upcoming-events/upcoming-events.spec.js
+++ b/src/components/upcoming-events/upcoming-events.spec.js
@@ -103,20 +103,20 @@ describe('Components/Upcoming Events', () => {
       // 1, 3, 0, 2, 4
       ORDERED_EVENTS = [{
         ...MULTIPLE_EVENTS[1],
-        isNext: true,
+        isNext: true
       }, {
         ...MULTIPLE_EVENTS[3],
-        isNext: false,
+        isNext: false
       }, {
         ...MULTIPLE_EVENTS[0],
-        isNext: false,
+        isNext: false
       }, {
         ...MULTIPLE_EVENTS[2],
-        isNext: false,
+        isNext: false
       }, {
         ...MULTIPLE_EVENTS[4],
-        isNext: false,
-      }]
+        isNext: false
+      }];
     });
 
     it('should not display the no upcoming events text', () => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,9 +9,12 @@ export default class Home extends HTMLElement {
     const events = (await fetch('https://www.analogstudios.net/api/v2/events?tag=tt')
       .then(resp => resp.json()))
       .map(event => {
+        const { startTime, endTime } = event;
+
         return {
           ...event,
-          startTime: event.startTime * 1000
+          startTime: startTime * 1000,
+          endTime: endTime * 1000
         };
       });
 


### PR DESCRIPTION
## Related Issue
Resolves #106 

## Summary of Changes
- Previously, the calculation for determining the next upcoming event was being done **_after_** grouping by date.
- These changes find the next upcoming event **_before_** grouping, and then append an "isNext" prop to the event object after grouping. Now when we are checking if the object should have the indicator or not, we don't have to call a bunch of unnecessary functions, it just checks if isNext is true.
