### PR TITLE
bump ESLint ECMA version support

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   plugins: [


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Want support for newer ECMA features like
- `import.meta.url`
- `obj?.property` (Optional Chaining, per #108 )

## Summary of Changes
1. Bump ESLint ECMA version to `2020`