### PR TITLE
fix malformed title attributes for event details link tags

### DIFF
--- a/src/components/upcoming-events/upcoming-events.js
+++ b/src/components/upcoming-events/upcoming-events.js
@@ -74,7 +74,7 @@ export default class UpcomingEvents extends HTMLElement {
                   const hour = hours > 12 ? hours - 12 : hours; // here we assume an 8pm (e.g. afternoon) start time
                   const formattedTitle = `${title.replace(/"/g, '\'')} @ ${hour}pm`; // TODO https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/issues/47
                   const eventLink = link
-                    ? `<a title="${title}" href="${link}" class="underline">${formattedTitle}</a>`
+                    ? `<a title="${title.replace(/"/g, '\'')}" href="${link}" class="underline">${formattedTitle}</a>`
                     : formattedTitle;
 
                   return `


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

`<a>` tags are malformed
```html
<a title="Tuesday" s="" tunes="" -="" 4="" 2023"="" href="https://www.facebook.com/events/s/tuesdays-tunes-songs-i-heard-i/590099316393951/" class="underline">Tuesday's Tunes - 4/4/2023 @ 8pm</a> 
```
![Screen Shot 2023-04-15 at 11 10 25 AM](https://user-images.githubusercontent.com/895923/232233784-e716321f-af01-4605-aa7a-a33c570b0746.png)


## Summary of Changes
1. fix malformed title attributes for event details link tags